### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/data/price.py
+++ b/data/price.py
@@ -49,7 +49,7 @@ class PriceHandler(object):
         inv_prices_dict = dict(
             (k, v) for k,v in [
                 (
-                    "%s%s" % (p[3:], p[:3]), 
+                    "{0!s}{1!s}".format(p[3:], p[:3]), 
                     {"bid": None, "ask": None, "time": None}
                 ) for p in self.pairs
             ]
@@ -64,7 +64,7 @@ class PriceHandler(object):
         "USDGBP" and place them in the prices dictionary.
         """
         getcontext().rounding = ROUND_HALF_DOWN
-        inv_pair = "%s%s" % (pair[3:], pair[:3])
+        inv_pair = "{0!s}{1!s}".format(pair[3:], pair[:3])
         inv_bid = (Decimal("1.0")/bid).quantize(
             Decimal("0.00001")
         )
@@ -136,7 +136,7 @@ class HistoricCSVPriceHandler(PriceHandler):
         in a chronological fashion.
         """
         for p in self.pairs:
-            pair_path = os.path.join(self.csv_dir, '%s_%s.csv' % (p, date_str))
+            pair_path = os.path.join(self.csv_dir, '{0!s}_{1!s}.csv'.format(p, date_str))
             self.pair_frames[p] = pd.io.parsers.read_csv(
                 pair_path, header=True, index_col=0, 
                 parse_dates=True, dayfirst=True,

--- a/data/streaming.py
+++ b/data/streaming.py
@@ -30,7 +30,7 @@ class StreamingForexPrices(PriceHandler):
         "USDGBP" and place them in the prices dictionary.
         """
         getcontext().rounding = ROUND_HALF_DOWN
-        inv_pair = "%s%s" % (pair[3:], pair[:3])
+        inv_pair = "{0!s}{1!s}".format(pair[3:], pair[:3])
         inv_bid = (Decimal("1.0")/bid).quantize(
             Decimal("0.00001")
         )
@@ -40,7 +40,7 @@ class StreamingForexPrices(PriceHandler):
         return inv_pair, inv_bid, inv_ask
 
     def connect_to_stream(self):
-        pairs_oanda = ["%s_%s" % (p[:3], p[3:]) for p in self.pairs]
+        pairs_oanda = ["{0!s}_{1!s}".format(p[:3], p[3:]) for p in self.pairs]
         pair_list = ",".join(pairs_oanda)
         try:
             requests.packages.urllib3.disable_warnings()
@@ -67,7 +67,7 @@ class StreamingForexPrices(PriceHandler):
                     msg = json.loads(dline)
                 except Exception as e:
                     self.logger.error(
-                        "Caught exception when converting message into json: %s" % str(e)
+                        "Caught exception when converting message into json: {0!s}".format(str(e))
                     )
                     return
                 if "instrument" in msg or "tick" in msg:

--- a/event/event.py
+++ b/event/event.py
@@ -11,7 +11,7 @@ class TickEvent(Event):
         self.ask = ask
 
     def __str__(self):
-        return "Type: %s, Instrument: %s, Time: %s, Bid: %s, Ask: %s" % (
+        return "Type: {0!s}, Instrument: {1!s}, Time: {2!s}, Bid: {3!s}, Ask: {4!s}".format(
             str(self.type), str(self.instrument), 
             str(self.time), str(self.bid), str(self.ask)
         )
@@ -29,7 +29,7 @@ class SignalEvent(Event):
         self.time = time  # Time of the last tick that generated the signal
 
     def __str__(self):
-        return "Type: %s, Instrument: %s, Order Type: %s, Side: %s" % (
+        return "Type: {0!s}, Instrument: {1!s}, Order Type: {2!s}, Side: {3!s}".format(
             str(self.type), str(self.instrument), 
             str(self.order_type), str(self.side)
         )
@@ -47,7 +47,7 @@ class OrderEvent(Event):
         self.side = side
 
     def __str__(self):
-        return "Type: %s, Instrument: %s, Units: %s, Order Type: %s, Side: %s" % (
+        return "Type: {0!s}, Instrument: {1!s}, Units: {2!s}, Order Type: {3!s}, Side: {4!s}".format(
             str(self.type), str(self.instrument), str(self.units),
             str(self.order_type), str(self.side)
         )

--- a/execution/execution.py
+++ b/execution/execution.py
@@ -54,7 +54,7 @@ class OANDAExecutionHandler(ExecutionHandler):
         return httplib.HTTPSConnection(self.domain)
 
     def execute_order(self, event):
-        instrument = "%s_%s" % (event.instrument[:3], event.instrument[3:])
+        instrument = "{0!s}_{1!s}".format(event.instrument[:3], event.instrument[3:])
         headers = {
             "Content-Type": "application/x-www-form-urlencoded",
             "Authorization": "Bearer " + self.access_token
@@ -67,7 +67,7 @@ class OANDAExecutionHandler(ExecutionHandler):
         })
         self.conn.request(
             "POST", 
-            "/v1/accounts/%s/orders" % str(self.account_id), 
+            "/v1/accounts/{0!s}/orders".format(str(self.account_id)), 
             params, headers
         )
         response = self.conn.getresponse().read().decode("utf-8").replace("\n","").replace("\t","")

--- a/portfolio/portfolio.py
+++ b/portfolio/portfolio.py
@@ -77,7 +77,7 @@ class Portfolio(object):
         out_file = open(os.path.join(OUTPUT_RESULTS_DIR, filename), "w")
         header = "Timestamp,Balance"
         for pair in self.ticker.pairs:
-            header += ",%s" % pair
+            header += ",{0!s}".format(pair)
         header += "\n"
         out_file.write(header)
         if self.backtest:
@@ -106,7 +106,7 @@ class Portfolio(object):
         df["Drawdown"] = drawdown
         df.to_csv(out_file, index=True)
         
-        print("Simulation complete and results exported to %s" % out_filename)
+        print("Simulation complete and results exported to {0!s}".format(out_filename))
 
     def update_portfolio(self, tick_event):
         """
@@ -118,10 +118,10 @@ class Portfolio(object):
             ps = self.positions[currency_pair]
             ps.update_position_price()
         if self.backtest:
-            out_line = "%s,%s" % (tick_event.time, self.balance)
+            out_line = "{0!s},{1!s}".format(tick_event.time, self.balance)
             for pair in self.ticker.pairs:
                 if pair in self.positions:
-                    out_line += ",%s" % self.positions[pair].profit_base
+                    out_line += ",{0!s}".format(self.positions[pair].profit_base)
                 else:
                     out_line += ",0.00"
             out_line += "\n"
@@ -187,7 +187,7 @@ class Portfolio(object):
             order = OrderEvent(currency_pair, units, "market", side)
             self.events.put(order)
 
-            self.logger.info("Portfolio Balance: %s" % self.balance)
+            self.logger.info("Portfolio Balance: {0!s}".format(self.balance))
         else:
             self.logger.info("Unable to execute order as price data was insufficient.")
         

--- a/portfolio/position.py
+++ b/portfolio/position.py
@@ -19,7 +19,7 @@ class Position(object):
         self.base_currency = self.currency_pair[:3]    # For EUR/USD, this is EUR
         self.quote_currency = self.currency_pair[3:]   # For EUR/USD, this is USD
         # For EUR/USD, with account denominated in GBP, this is USD/GBP
-        self.quote_home_currency_pair = "%s%s" % (self.quote_currency, self.home_currency)
+        self.quote_home_currency_pair = "{0!s}{1!s}".format(self.quote_currency, self.home_currency)
 
         ticker_cur = self.ticker.prices[self.currency_pair]
         if self.position_type == "long":

--- a/scripts/generate_simulated_pair.py
+++ b/scripts/generate_simulated_pair.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
             outfile = open(
                 os.path.join(
                     settings.CSV_DATA_DIR, 
-                    "%s_%s.csv" % (
+                    "{0!s}_{1!s}.csv".format(
                         pair, d.strftime("%Y%m%d")
                     )
                 ), 
@@ -72,9 +72,9 @@ if __name__ == "__main__":
                     bid += W
                     ask_volume = 1.0 + np.random.uniform(0.0, 2.0)
                     bid_volume = 1.0 + np.random.uniform(0.0, 2.0)
-                    line = "%s,%s,%s,%s,%s\n" % (
+                    line = "{0!s},{1!s},{2!s},{3!s},{4!s}\n".format(
                         current_time.strftime("%d.%m.%Y %H:%M:%S.%f")[:-3], 
-                        "%0.5f" % ask, "%0.5f" % bid,
-                        "%0.2f00" % ask_volume, "%0.2f00" % bid_volume
+                        "{0:0.5f}".format(ask), "{0:0.5f}".format(bid),
+                        "{0:0.2f}00".format(ask_volume), "{0:0.2f}00".format(bid_volume)
                     )
                     outfile.write(line)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:luca-heltai:qsforex?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:luca-heltai:qsforex?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
